### PR TITLE
Adding cookies from 33Across

### DIFF
--- a/open-cookie-database.csv
+++ b/open-cookie-database.csv
@@ -1405,3 +1405,4 @@ e189f48e-e02f-48c1-90da-da2b58b1252d,Gemius,Analytics,__gfp_s_64b,.gemius.pl,"Re
 46fe45bf-949d-4105-ac31-8c482828f11c,Nativo,Marketing,opt_out,postrelease.com,"This cookie is used to remember not to serve that user targeted Ads if they opt out.",1 year,Nativo,https://www.nativo.com/privacy-policy,0
 3b9031a0-098c-48b8-a333-4d9df9afc1df,Nativo,Marketing,visitor,postrelease.com,"This cookie is used to identify a unique visitor to the site.",1 year,Nativo,https://www.nativo.com/privacy-policy,0
 a1031b6e-685a-428b-b68a-b2f0911d770b,Bombora,Marketing,tp,.ml314.com,"This cookie is used to target the audience",14 days,Bombora,https://bombora.com/privacy-philosophy/,0
+7526cf70-157e-474a-9a50-ad5dfbe8d0cd,33Across,Marketing,33x_ps,.33across.com,"This cookie is used targeted and behavioural advertising services.",1 year,33Across,https://33across.com/privacy-policy/,0


### PR DESCRIPTION
This pull request contains one cookie from the 33Across platform.

Motivation

This cookie was present on the news portal, sic.pt and rtp.pt
